### PR TITLE
Bridge iconv() call to avoid bypassing GC write barrier

### DIFF
--- a/iconv.go
+++ b/iconv.go
@@ -9,6 +9,12 @@ package iconv
 // #include <iconv.h>
 // #include <stdlib.h>
 // #include <errno.h>
+//
+// size_t bridge_iconv(iconv_t cd,
+//		       char *inbuf, size_t *inbytesleft,
+//                     char *outbuf, size_t *outbytesleft) {
+//   return iconv(cd, &inbuf, inbytesleft, &outbuf, outbytesleft);
+// }
 import "C"
 
 import (
@@ -83,9 +89,9 @@ func (cd Iconv) Do(inbuf []byte, in int, outbuf []byte) (out, inleft int, err er
 
 	outbytes := C.size_t(len(outbuf))
 	outptr := &outbuf[0]
-	_, err = C.iconv(cd.Handle,
-		(**C.char)(unsafe.Pointer(&inptr)), &inbytes,
-		(**C.char)(unsafe.Pointer(&outptr)), &outbytes)
+	_, err = C.bridge_iconv(cd.Handle,
+		(*C.char)(unsafe.Pointer(inptr)), &inbytes,
+		(*C.char)(unsafe.Pointer(outptr)), &outbytes)
 
 	out = len(outbuf) - int(outbytes)
 	inleft = int(inbytes)
@@ -104,9 +110,9 @@ func (cd Iconv) DoWrite(w io.Writer, inbuf []byte, in int, outbuf []byte) (inlef
 	for inbytes > 0 {
 		outbytes := C.size_t(len(outbuf))
 		outptr := &outbuf[0]
-		_, err = C.iconv(cd.Handle,
-			(**C.char)(unsafe.Pointer(&inptr)), &inbytes,
-			(**C.char)(unsafe.Pointer(&outptr)), &outbytes)
+		_, err = C.bridge_iconv(cd.Handle,
+			(*C.char)(unsafe.Pointer(inptr)), &inbytes,
+			(*C.char)(unsafe.Pointer(outptr)), &outbytes)
 		w.Write(outbuf[:len(outbuf)-int(outbytes)])
 		if err != nil && err != E2BIG {
 			return int(inbytes), err


### PR DESCRIPTION
This PR introduces an indirection through a C bridge function so that we are not passing a pointer into the Go-managed stack directly to the C-level `iconv()`.  The latter would use that pointer to update a Go-managed variable and thereby bypass the [Go 1.5] write barrier, causing problems during GC.

Bypassing the write barrier leads to errors like this when run with `GODEBUG=gccheckmark=1`:

```
runtime:objectstart Span weird: p=0xc821d30000 k=0x6410e98 s.start=0xc821d30000 s.limit=0xc821d98000 s.state=2
fatal error: objectstart: bad pointer in unexpected span

goroutine 12 [running]:
runtime.throw(0xb4f320, 0x2b)
	/usr/local/go/src/runtime/panic.go:527 +0x90 fp=0xc820028e10 sp=0xc820028df8
runtime.heapBitsForObject(0xc821d30000, 0x0, 0x0, 0xc800000000, 0x7ff7a130dd00)
	/usr/local/go/src/runtime/mbitmap.go:217 +0x287 fp=0xc820028e48 sp=0xc820028e10
runtime.scanobject(0xc8217c8050, 0xc820023c20)
	/usr/local/go/src/runtime/mgcmark.go:863 +0x239 fp=0xc820028f18 sp=0xc820028e48
runtime.gcDrainUntilPreempt(0xc820023c20, 0x7d0)
	/usr/local/go/src/runtime/mgcmark.go:726 +0x152 fp=0xc820028f50 sp=0xc820028f18
runtime.gcBgMarkWorker(0xc820022a00)
	/usr/local/go/src/runtime/mgc.go:1328 +0x474 fp=0xc820028fb8 sp=0xc820028f50
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1 fp=0xc820028fc0 sp=0xc820028fb8
created by runtime.gcBgMarkStartWorkers
	/usr/local/go/src/runtime/mgc.go:1238 +0x93

[...]

goroutine 105 [runnable, locked to thread]:
github.com/qiniu/iconv._C2func_iconv(0x7ff788018ce0, 0xc8201a0158, 0xc82018e1e0, 0xc8201a0160, 0xc82018e1f0, 0x0, 0x0, 0x0)
	github.com/qiniu/iconv/_obj/_cgo_gotypes.go:49 +0x51
github.com/qiniu/iconv.Iconv.Do(0x7ff788018ce0, 0xc821d2f000, 0x1000, 0x1000, 0x1000, 0xc821d2e000, 0x1000, 0x1000, 0x0, 0x0, ...)
	/go/src/github.com/civitaslearning/firehose/Godeps/_workspace/src/github.com/qiniu/iconv/iconv.go:83 +0x149
github.com/civitaslearning/firehose/workflow/processor/transcode.(*reader).fetch(0xc82015f200, 0x0, 0x0)
```