### PR TITLE
Build C wrapper func to avoid double pointer in Go.

### DIFF
--- a/iconv.go
+++ b/iconv.go
@@ -9,6 +9,11 @@ package iconv
 // #include <iconv.h>
 // #include <stdlib.h>
 // #include <errno.h>
+// #include <stdio.h>
+//
+// size_t iconv_bridge(iconv_t t, char *in, size_t *in_size, char *out, size_t *out_size) {
+//                           return iconv(t, &in, in_size, &out, out_size);
+// }
 import "C"
 
 import (
@@ -83,9 +88,9 @@ func (cd Iconv) Do(inbuf []byte, in int, outbuf []byte) (out, inleft int, err er
 
 	outbytes := C.size_t(len(outbuf))
 	outptr := &outbuf[0]
-	_, err = C.iconv(cd.Handle,
-		(**C.char)(unsafe.Pointer(&inptr)), &inbytes,
-		(**C.char)(unsafe.Pointer(&outptr)), &outbytes)
+	_, err = C.iconv_bridge(cd.Handle,
+		(*C.char)(unsafe.Pointer(inptr)), &inbytes,
+		(*C.char)(unsafe.Pointer(outptr)), &outbytes)
 
 	out = len(outbuf) - int(outbytes)
 	inleft = int(inbytes)
@@ -104,9 +109,9 @@ func (cd Iconv) DoWrite(w io.Writer, inbuf []byte, in int, outbuf []byte) (inlef
 	for inbytes > 0 {
 		outbytes := C.size_t(len(outbuf))
 		outptr := &outbuf[0]
-		_, err = C.iconv(cd.Handle,
-			(**C.char)(unsafe.Pointer(&inptr)), &inbytes,
-			(**C.char)(unsafe.Pointer(&outptr)), &outbytes)
+		_, err = C.iconv_bridge(cd.Handle,
+			(*C.char)(unsafe.Pointer(inptr)), &inbytes,
+			(*C.char)(unsafe.Pointer(outptr)), &outbytes)
 		w.Write(outbuf[:len(outbuf)-int(outbytes)])
 		if err != nil && err != E2BIG {
 			return int(inbytes), err


### PR DESCRIPTION
Fixes iconv for use in go 1.6 as discussed here: https://github.com/qiniu/iconv/issues/31#issuecomment-188171272
Also fixes a problem in go 1.5 which happened sometimes during a GC:
```
runtime:objectstart Span weird: p=0xc8205ac000 k=0x64102d6 s.start=0xc8205ac000 s.limit=0xc8205adf80 s.state=2
fatal error: objectstart: bad pointer in unexpected span

goroutine 72 [running]:
runtime.throw(0x93ed60, 0x2b)
	/home/cdb/projects/go/go1.5.1/src/runtime/panic.go:527 +0x90 fp=0xc820376e18 sp=0xc820376e00
runtime.heapBitsForObject(0xc8205ac000, 0x0, 0x0, 0xc800000000, 0x7f9469315ab0)
	/home/cdb/projects/go/go1.5.1/src/runtime/mbitmap.go:217 +0x287 fp=0xc820376e50 sp=0xc820376e18
runtime.scanobject(0xc82002c090, 0xc82001d220)
	/home/cdb/projects/go/go1.5.1/src/runtime/mgcmark.go:878 +0x239 fp=0xc820376f20 sp=0xc820376e50
runtime.gcDrain(0xc82001d220, 0x7d0)
	/home/cdb/projects/go/go1.5.1/src/runtime/mgcmark.go:689 +0xf4 fp=0xc820376f50 sp=0xc820376f20
runtime.gcBgMarkWorker(0xc82001c000)
	/home/cdb/projects/go/go1.5.1/src/runtime/mgc.go:1320 +0x281 fp=0xc820376fb8 sp=0xc820376f50
runtime.goexit()
	/home/cdb/projects/go/go1.5.1/src/runtime/asm_amd64.s:1696 +0x1 fp=0xc820376fc0 sp=0xc820376fb8
created by runtime.gcBgMarkStartWorkers
	/home/cdb/projects/go/go1.5.1/src/runtime/mgc.go:1239 +0x93

```